### PR TITLE
add atomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Voir [TODO.md](TODO.md) pour la roadmap complète.
 - [x] MIDI input
 - [x] Oscillateurs de base
 - [x] Polyphonie
-- [ ] UI basique
+- [x] UI basique
 - [ ] Tests d'intégration
 
 ### Phase 2

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@
 - [x] Créer le système de communication lock-free (ringbuffer)
   - [x] Channel MIDI → Audio
   - [x] Channel UI → Audio
-  - [ ] Atomics pour les paramètres (volume, etc.) - À FAIRE
+  - [x] Atomics pour les paramètres (volume, etc.)
 
 ### Synthèse
 - [x] Implémenter les oscillateurs de base
@@ -37,7 +37,7 @@
 ### Interface utilisateur
 - [x] Créer l'UI de base avec egui/eframe
   - [x] Fenêtre principale
-  - [x] Slider de volume (affiché mais pas connecté)
+  - [x] Slider de volume (connecté via atomics)
   - [ ] Sélecteur de forme d'onde - À FAIRE
   - [x] Visualisation des notes actives
   - [x] Clavier virtuel avec touches PC (A W S E D F T G Y H U J K)

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -3,3 +3,4 @@
 pub mod engine;
 pub mod device;
 pub mod buffer;
+pub mod parameters;

--- a/src/audio/parameters.rs
+++ b/src/audio/parameters.rs
@@ -1,0 +1,36 @@
+// Atomic parameters - Lock-free communication UI ↔ Audio thread
+// Uses atomic operations to share parameters between threads without locks
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+/// Thread-safe f32 parameter using atomic operations
+/// Converts f32 to u32 bits for atomic storage
+#[derive(Clone)]
+pub struct AtomicF32 {
+    inner: Arc<AtomicU32>,
+}
+
+impl AtomicF32 {
+    pub fn new(value: f32) -> Self {
+        Self {
+            inner: Arc::new(AtomicU32::new(value.to_bits())),
+        }
+    }
+
+    /// Set the value (called from UI thread)
+    pub fn set(&self, value: f32) {
+        self.inner.store(value.to_bits(), Ordering::Relaxed);
+    }
+
+    /// Get the value (called from audio thread)
+    pub fn get(&self) -> f32 {
+        f32::from_bits(self.inner.load(Ordering::Relaxed))
+    }
+}
+
+impl Default for AtomicF32 {
+    fn default() -> Self {
+        Self::new(0.0)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     let (command_tx_midi, command_rx_midi) = create_command_channel(512);
 
     println!("Audio engine initialisation...");
-    let _audio_engine = match AudioEngine::new(command_rx_ui, command_rx_midi) {
+    let audio_engine = match AudioEngine::new(command_rx_ui, command_rx_midi) {
         Ok(engine) => engine,
         Err(e) => {
             eprintln!("ERROR: {}", e);
@@ -44,6 +44,6 @@ fn main() {
     let _ = eframe::run_native(
         "MyMusic DAW",
         native_options,
-        Box::new(|_cc| Ok(Box::new(DawApp::new(command_tx_ui)))),
+        Box::new(|_cc| Ok(Box::new(DawApp::new(command_tx_ui, audio_engine.volume.clone())))),
     );
 }


### PR DESCRIPTION
This pull request implements thread-safe, lock-free communication for the volume parameter between the UI and audio engine using atomics, and fully connects the UI volume slider to the audio engine. It introduces an `AtomicF32` parameter for volume, updates both the audio engine and UI to use this atomic parameter, and marks related TODOs as complete.

**Thread-safe parameter communication:**
* Added `AtomicF32` type in `src/audio/parameters.rs` to allow lock-free, thread-safe sharing of floating-point parameters (like volume) between UI and audio threads.
* Updated `AudioEngine` (`src/audio/engine.rs`) to use `AtomicF32` for the `volume` parameter, ensuring atomic reads/writes and safe sharing across threads.

**UI integration:**
* Modified `DawApp` in `src/ui/app.rs` to use the atomic volume parameter, synchronizing the UI slider with the audio engine in real time. The slider now updates the shared atomic volume, which is read by the audio thread.
* Changed app initialization in `src/main.rs` to pass the atomic volume parameter from the audio engine to the UI. 

**Documentation and TODO updates:**
* Marked the "UI basique" and "Atomics pour les paramètres (volume, etc.)" tasks as complete in `README.md` and `TODO.md`. Also updated the UI volume slider item to indicate it is now connected via atomics.