### PR TITLE
fix: Add missing notification_tx field and remove unused import

### DIFF
--- a/src/audio/engine.rs
+++ b/src/audio/engine.rs
@@ -24,7 +24,7 @@
 // mais la reconnexion doit être gérée manuellement.
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig, SupportedStreamConfig};
+use cpal::{Device, FromSample, Sample, SampleFormat, SizedSample, Stream, StreamConfig};
 use std::sync::{Arc, Mutex};
 
 use crate::audio::cpu_monitor::CpuMonitor;

--- a/src/midi/manager.rs
+++ b/src/midi/manager.rs
@@ -38,6 +38,7 @@ impl MidiConnectionManager {
                 status,
                 target_device,
                 command_tx,
+                notification_tx,
                 _monitor_thread: None,
             };
         }


### PR DESCRIPTION
- Add notification_tx to MidiConnectionManager when MIDI is unavailable
- Remove unused SupportedStreamConfig import from audio engine
- Fixes compilation error in src/midi/manager.rs:36